### PR TITLE
Fail the grunt task when there's an error.

### DIFF
--- a/tasks/eco.js
+++ b/tasks/eco.js
@@ -84,6 +84,8 @@ module.exports = function(grunt) {
 
         if (res) {
           compiled.push(res);
+        } else {
+          grunt.fail.warn('eco failed to compile.');
         }
       });
 


### PR DESCRIPTION
Before, grunt would print "Done, without errors" even after an error.
Additionally, the task would continue running, burying the error. (To preserve
the old behavior of continuing after an error, run grunt with --force.)
