### PR TITLE
Make eco task to fail on an error

### DIFF
--- a/tasks/eco.js
+++ b/tasks/eco.js
@@ -38,6 +38,7 @@ module.exports = function(grunt) {
       output = eco.compile(grunt.file.read(src)).replace(/module\.exports/, '');
     } catch (e) {
       grunt.log.error("Error in " + src + ":\n" + e);
+      grunt.fail.warn("Eco failed to compile " + src + ".");
       return false;
     }
 


### PR DESCRIPTION
I think it would be better to see the task to fail when there is an
error. This is a must have for integration tools.

Best,
David
